### PR TITLE
UIPageViewControllerTransitionStyleScroll bug

### DIFF
--- a/Example/CDAPdfReader/Main.storyboard
+++ b/Example/CDAPdfReader/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="whP-gf-Uak">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="whP-gf-Uak">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
@@ -103,7 +103,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xrw-go-xt4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="52" y="1140"/>
+            <point key="canvasLocation" x="40" y="1140"/>
         </scene>
         <!--Reader View Controller-->
         <scene sceneID="odu-Wt-26H">
@@ -111,7 +111,7 @@
                 <pageViewController autoresizesArchivedViewToFullSize="NO" transitionStyle="scroll" navigationOrientation="horizontal" spineLocation="none" id="glv-kN-CSb" customClass="CDAPDFReaderViewController" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="f7D-aH-hUZ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="93" y="2012"/>
+            <point key="canvasLocation" x="40" y="1890"/>
         </scene>
         <!--Reader View Controller-->
         <scene sceneID="Yzf-PG-LGr">
@@ -178,7 +178,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="geV-wv-Q4x" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="702" y="1730"/>
+            <point key="canvasLocation" x="679" y="1665"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
Fixed: On Scroll Transition style there is a bug that doesn't load correctly the previous page. So we need to load that previous page first, and then the new one